### PR TITLE
Delete .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,1 +1,0 @@
-examples


### PR DESCRIPTION
`examples` folder doesn't exist quite a long time (in fact it never existed, because old example folder was named `example` (without `s`))