### PR TITLE
Use the same property name for lat/lng object

### DIFF
--- a/RNGeocoder/RNGeocoder.m
+++ b/RNGeocoder/RNGeocoder.m
@@ -78,7 +78,7 @@ RCT_EXPORT_METHOD(geocodeAddress:(NSString *)address errorCallback: (RCTResponse
 
     NSDictionary *result = @{
      @"name": placemark.name ?: [NSNull null],
-     @"location": @{
+     @"position": @{
          @"lat": [NSNumber numberWithDouble:placemark.location.coordinate.latitude],
          @"lng": [NSNumber numberWithDouble:placemark.location.coordinate.longitude],
          },


### PR DESCRIPTION
#13 I choosed the Android name because it seems to fit better.
