### PR TITLE
Don't distribute ES6 code

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,19 +1,15 @@
-var {
-  NativeModules: {
-    RNGeocoder
-  }
-} = require('react-native');
+var RNGeocoder = require('react-native').NativeModules.RNGeocoder;
 
 var Geocoder = {
 
   reverseGeocodeLocation: function(location, callback) {
 
-    return new Promise((resolve, reject) => {
+    return new Promise(function (resolve, reject) {
 
-      RNGeocoder.reverseGeocodeLocation(location, (err) => {
+      RNGeocoder.reverseGeocodeLocation(location, function (err) {
         callback && callback(err, null);
         reject(err);
-      }, (data) => {
+      }, function (data) {
         callback && callback(null, data);
         resolve(data);
       });
@@ -22,12 +18,12 @@ var Geocoder = {
 
   geocodeAddress: function(address, callback) {
 
-    return new Promise((resolve, reject) => {
+    return new Promise(function (resolve, reject) {
 
-      RNGeocoder.geocodeAddress(address, (err) => {
+      RNGeocoder.geocodeAddress(address, function (err) {
         callback && callback(err, null);
         reject(err);
-      }, (data) => {
+      }, function (data) {
         callback && callback(null, data);
         resolve(data);
       });


### PR DESCRIPTION
I face an issue with Mocha for test unit : it doesn't allow babel to process node_modules code.

I took the decision to convert it to basic ES5 since the number of changes is very low. I think we should avoid to force user to use a transpiler even for testing.