### PR TITLE
Support parallel requests on iOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ both iOS and Android will return the following object:
 ## Notes
 
 ### iOS
-iOS does not allow sending multiple geocoding requests simultaneously.
+iOS does not allow sending multiple geocoding requests simultaneously, unless you enable the fallbackToGoogle to handle the parallel calls when an native iOS request is active.
 
 ### Android
 geocoding may not work on older android devices (4.1) and will not work if Google play services are not available.

--- a/ios/RNGeocoder/RNGeocoder.m
+++ b/ios/RNGeocoder/RNGeocoder.m
@@ -30,7 +30,9 @@ RCT_EXPORT_METHOD(geocodePosition:(CLLocation *)location
     self.geocoder = [[CLGeocoder alloc] init];
   }
 
-  [self.geocoder cancelGeocode];
+  if (self.geocoder.geocoding) {
+    return reject(@"NOT_AVAILABLE", @"geocodePosition busy", nil);
+  }
 
   [self.geocoder reverseGeocodeLocation:location completionHandler:^(NSArray *placemarks, NSError *error) {
 
@@ -55,16 +57,18 @@ RCT_EXPORT_METHOD(geocodeAddress:(NSString *)address
         self.geocoder = [[CLGeocoder alloc] init];
     }
 
-    [self.geocoder cancelGeocode];
+    if (self.geocoder.geocoding) {
+      return reject(@"NOT_AVAILABLE", @"geocodeAddress busy", nil);
+    }
 
     [self.geocoder geocodeAddressString:address completionHandler:^(NSArray *placemarks, NSError *error) {
 
         if (error) {
             if (placemarks.count == 0) {
-              return reject(@"NOT_FOUND", @"geocodePosition failed", error);
+              return reject(@"NOT_FOUND", @"geocodeAddress failed", error);
             }
 
-            return reject(@"ERROR", @"geocodePosition failed", error);
+            return reject(@"ERROR", @"geocodeAddress failed", error);
         }
 
         resolve([self placemarksToDictionary:placemarks]);


### PR DESCRIPTION
When a geocode is in progress on iOS, let it finish, and mark our new…geocode request as unavailable. This will let it potentially fallback to using the google maps geocoder. This lets parallel geocodes work on iOS when called from multiple unrelated async functions.