### PR TITLE
Add `region` to the result

### DIFF
--- a/android/src/main/java/com/devfd/RNGeocoder/RNGeocoderModule.java
+++ b/android/src/main/java/com/devfd/RNGeocoder/RNGeocoderModule.java
@@ -73,6 +73,8 @@ public class RNGeocoderModule extends ReactContextBaseJavaModule {
             position.putDouble("lat", address.getLatitude());
             position.putDouble("lng", address.getLongitude());
             result.putMap("position", position);
+            // There is no radius field in the `Address` object.
+            result.putString("radius", null);
 
             final String feature_name = address.getFeatureName();
             if (feature_name != null && !feature_name.equals(address.getSubThoroughfare()) &&

--- a/android/src/main/java/com/devfd/RNGeocoder/RNGeocoderModule.java
+++ b/android/src/main/java/com/devfd/RNGeocoder/RNGeocoderModule.java
@@ -73,8 +73,9 @@ public class RNGeocoderModule extends ReactContextBaseJavaModule {
             position.putDouble("lat", address.getLatitude());
             position.putDouble("lng", address.getLongitude());
             result.putMap("position", position);
-            // There is no radius field in the `Address` object.
-            result.putString("radius", null);
+
+            // There is no region field in the `Address` object.
+            result.putString("region", null);
 
             final String feature_name = address.getFeatureName();
             if (feature_name != null && !feature_name.equals(address.getSubThoroughfare()) &&

--- a/ios/RNGeocoder/RNGeocoder.m
+++ b/ios/RNGeocoder/RNGeocoder.m
@@ -100,6 +100,7 @@ RCT_EXPORT_METHOD(geocodeAddress:(NSString *)address
          @"lat": [NSNumber numberWithDouble:placemark.location.coordinate.latitude],
          @"lng": [NSNumber numberWithDouble:placemark.location.coordinate.longitude],
          },
+     @"radius": [NSNumber numberWithDouble:[(CLCircularRegion *)placemark.region radius]] ?: [NSNull null],
      @"country": placemark.country ?: [NSNull null],
      @"countryCode": placemark.ISOcountryCode ?: [NSNull null],
      @"locality": placemark.locality ?: [NSNull null],

--- a/ios/RNGeocoder/RNGeocoder.m
+++ b/ios/RNGeocoder/RNGeocoder.m
@@ -81,6 +81,7 @@ RCT_EXPORT_METHOD(geocodeAddress:(NSString *)address
 
   for (int i = 0; i < placemarks.count; i++) {
     CLPlacemark* placemark = [placemarks objectAtIndex:i];
+    CLCircularRegion* region = placemark.region;
 
     NSString* name = [NSNull null];
 
@@ -100,7 +101,13 @@ RCT_EXPORT_METHOD(geocodeAddress:(NSString *)address
          @"lat": [NSNumber numberWithDouble:placemark.location.coordinate.latitude],
          @"lng": [NSNumber numberWithDouble:placemark.location.coordinate.longitude],
          },
-     @"radius": [NSNumber numberWithDouble:[(CLCircularRegion *)placemark.region radius]] ?: [NSNull null],
+     @"region": placemark.region ? @{
+         @"center": @{
+             @"lat": [NSNumber numberWithDouble:region.center.latitude],
+             @"lng": [NSNumber numberWithDouble:region.center.longitude],
+             },
+         @"radius": [NSNumber numberWithDouble:region.radius],
+         } : [NSNull null],
      @"country": placemark.country ?: [NSNull null],
      @"countryCode": placemark.ISOcountryCode ?: [NSNull null],
      @"locality": placemark.locality ?: [NSNull null],
@@ -110,7 +117,7 @@ RCT_EXPORT_METHOD(geocodeAddress:(NSString *)address
      @"postalCode": placemark.postalCode ?: [NSNull null],
      @"adminArea": placemark.administrativeArea ?: [NSNull null],
      @"subAdminArea": placemark.subAdministrativeArea ?: [NSNull null],
-     @"formattedAddress": [lines componentsJoinedByString:@", "]
+     @"formattedAddress": [lines componentsJoinedByString:@", "],
    };
 
     [results addObject:result];

--- a/js/geocoder.js
+++ b/js/geocoder.js
@@ -10,6 +10,18 @@ export default {
     this.apiKey = key;
   },
 
+  geocodePositionFallback(position) {
+    if (!this.apiKey) { throw new Error("Google API key required"); }
+
+    return GoogleApi.geocodePosition(this.apiKey, position);
+  },
+
+  geocodeAddressFallback(address) {
+    if (!this.apiKey) { throw new Error("Google API key required"); }
+
+    return GoogleApi.geocodeAddress(this.apiKey, address);
+  },
+
   geocodePosition(position) {
     if (!position || !position.lat || !position.lng) {
       return Promise.reject(new Error("invalid position: {lat, lng} required"));
@@ -17,7 +29,7 @@ export default {
 
     return RNGeocoder.geocodePosition(position).catch(err => {
       if (!this.apiKey || err.code !== 'NOT_AVAILABLE') { throw err; }
-      return GoogleApi.geocodePosition(this.apiKey, position);
+      return this.geocodePositionFallback(position);
     });
   },
 
@@ -28,7 +40,7 @@ export default {
 
     return RNGeocoder.geocodeAddress(address).catch(err => {
       if (!this.apiKey || err.code !== 'NOT_AVAILABLE') { throw err; }
-      return GoogleApi.geocodeAddress(this.apiKey, address);
+      return this.geocodeAddressFallback(address);
     });
   },
 }

--- a/js/geocoder.js
+++ b/js/geocoder.js
@@ -28,7 +28,7 @@ export default {
     }
 
     return RNGeocoder.geocodePosition(position).catch(err => {
-      if (!this.apiKey || err.code !== 'NOT_AVAILABLE') { throw err; }
+      if (err.code !== 'NOT_AVAILABLE') { throw err; }
       return this.geocodePositionFallback(position);
     });
   },
@@ -39,7 +39,7 @@ export default {
     }
 
     return RNGeocoder.geocodeAddress(address).catch(err => {
-      if (!this.apiKey || err.code !== 'NOT_AVAILABLE') { throw err; }
+      if (err.code !== 'NOT_AVAILABLE') { throw err; }
       return this.geocodeAddressFallback(address);
     });
   },

--- a/js/googleApi.js
+++ b/js/googleApi.js
@@ -1,8 +1,11 @@
+import { getCenterOfBounds, getDistance } from 'geolib';
+
 const googleUrl = 'https://maps.google.com/maps/api/geocode/json';
 
 function format(raw) {
   const address = {
     position: {},
+    region: null,
     formattedAddress: raw.formatted_address || '',
     feature: null,
     streetNumber: null,
@@ -20,6 +23,27 @@ function format(raw) {
     address.position = {
       lat: raw.geometry.location.lat,
       lng: raw.geometry.location.lng,
+    }
+
+    if (raw.geometry.viewport) {
+      const northEast = {
+        latitude: raw.geometry.viewport.northeast.lat,
+        longitude: raw.geometry.viewport.northeast.lng,
+      };
+      const southWest = {
+        latitude: raw.geometry.viewport.southwest.lat,
+        longitude: raw.geometry.viewport.southwest.lng,
+      };
+      const center = getCenterOfBounds([northEast, southWest]);
+      const radius = getDistance(center, northEast);
+
+      address.region = {
+        center: {
+          lat: center.latitude,
+          lng: center.longitude,
+        },
+        radius,
+      }
     }
   }
 

--- a/test/unit/googleApi.test.js
+++ b/test/unit/googleApi.test.js
@@ -51,6 +51,9 @@ describe('googleApi', function() {
       it ('for waterloo-bridge', async function() {
         mockFetch(require('./fixtures/waterloo-bridge.js'));
         let [first, ...ret] = await GoogleApi.geocodeRequest();
+        expect(first.region.center.lat).to.eql(51.506349);
+        expect(first.region.center.lng).to.eql(-0.114699);
+        expect(first.region.radius).to.eql(177);
         expect(first.countryCode).to.eql('GB');
         expect(first.feature).to.be.eql(null);
         expect(first.locality).to.eql('London');
@@ -61,6 +64,9 @@ describe('googleApi', function() {
       it ('for yosemite park', async function() {
         mockFetch(require('./fixtures/yosemite-park.js'));
         let [first, ...ret] = await GoogleApi.geocodeRequest();
+        expect(first.region.center.lat).to.eql(37.865101);
+        expect(first.region.center.lng).to.eql(-119.538329);
+        expect(first.region.radius).to.eql(191);
         expect(first.countryCode).to.eql('US');
         expect(first.feature).to.be.eql('Yosemite National Park');
         expect(first.streetName).to.be.eql(null);


### PR DESCRIPTION
Sometimes, we need `region` of the geocoded result, for example, to decide the zoom level. This PR adds `region` to iOS and Google API fallback results, but on Android `region` will be `null` always since it doesn't support the feature.