### PR TITLE
Fallback to Google Maps Web API when Geocoder does not work

### DIFF
--- a/android/src/main/java/com/devfd/RNGeocoder/RNGeocoderModule.java
+++ b/android/src/main/java/com/devfd/RNGeocoder/RNGeocoderModule.java
@@ -39,7 +39,7 @@ public class RNGeocoderModule extends ReactContextBaseJavaModule {
 
         try {
             List<Address> addresses = geocoder.getFromLocationName(addressName, 20);
-            if(addresses != null && addresses.size() > 0 {
+            if(addresses != null && addresses.size() > 0) {
                 promise.resolve(transform(addresses));
             } else {
                 promise.reject("NO_RESULTS", "Geocoder returned an empty list");

--- a/android/src/main/java/com/devfd/RNGeocoder/RNGeocoderModule.java
+++ b/android/src/main/java/com/devfd/RNGeocoder/RNGeocoderModule.java
@@ -42,7 +42,7 @@ public class RNGeocoderModule extends ReactContextBaseJavaModule {
             if(addresses != null && addresses.size() > 0) {
                 promise.resolve(transform(addresses));
             } else {
-                promise.reject("NO_RESULTS", "Geocoder returned an empty list");
+                promise.reject("NOT_AVAILABLE", "Geocoder returned an empty list");
             }
 
         }

--- a/android/src/main/java/com/devfd/RNGeocoder/RNGeocoderModule.java
+++ b/android/src/main/java/com/devfd/RNGeocoder/RNGeocoderModule.java
@@ -39,7 +39,12 @@ public class RNGeocoderModule extends ReactContextBaseJavaModule {
 
         try {
             List<Address> addresses = geocoder.getFromLocationName(addressName, 20);
-            promise.resolve(transform(addresses));
+            if(addresses != null && addresses.size() > 0 {
+                promise.resolve(transform(addresses));
+            } else {
+                promise.reject("NO_RESULTS", "Geocoder returned an empty list");
+            }
+
         }
 
         catch (IOException e) {

--- a/js/geocoder.js
+++ b/js/geocoder.js
@@ -10,14 +10,26 @@ export default {
     this.apiKey = key;
   },
 
+  geocodePositionFallback(position) {
+    if (!this.apiKey) { throw new Error("Google API key required"); }
+
+    return GoogleApi.geocodePosition(this.apiKey, position);
+  },
+
+  geocodeAddressFallback(address) {
+    if (!this.apiKey) { throw new Error("Google API key required"); }
+
+    return GoogleApi.geocodeAddress(this.apiKey, address);
+  },
+
   geocodePosition(position) {
     if (!position || !position.lat || !position.lng) {
       return Promise.reject(new Error("invalid position: {lat, lng} required"));
     }
 
     return RNGeocoder.geocodePosition(position).catch(err => {
-      if (!this.apiKey || err.code !== 'NOT_AVAILABLE') { throw err; }
-      return GoogleApi.geocodePosition(this.apiKey, position);
+      if (err.code !== 'NOT_AVAILABLE') { throw err; }
+      return this.geocodePositionFallback(position);
     });
   },
 
@@ -27,8 +39,8 @@ export default {
     }
 
     return RNGeocoder.geocodeAddress(address).catch(err => {
-      if (!this.apiKey || err.code !== 'NOT_AVAILABLE') { throw err; }
-      return GoogleApi.geocodeAddress(this.apiKey, address);
+      if (err.code !== 'NOT_AVAILABLE') { throw err; }
+      return this.geocodeAddressFallback(address);
     });
   },
 }


### PR DESCRIPTION
I was having a problem since not all valid addresses were being geocoded properly. There were very specific addresses that the Android Geocoder would return an empty list. Because of that, and motivated by [this comment](http://stackoverflow.com/a/24805337/914037 ), it seemed appropriate to fallback to the web API when the Geocoder returned an empty list. That fixed my issue.