### PR TITLE
On new request cancel the previous one (iOS)

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ both iOS and Android will return the following object:
 ## Notes
 
 ### iOS
-iOS does not allow sending multiple geocoding requests simultaneously, unless you enable the fallbackToGoogle to handle the parallel calls when an native iOS request is active.
+iOS does not allow sending multiple geocoding requests simultaneously, hence if you send a second call, the first one will be cancelled.
 
 ### Android
 geocoding may not work on older android devices (4.1) and will not work if Google play services are not available.

--- a/ios/RNGeocoder/RNGeocoder.m
+++ b/ios/RNGeocoder/RNGeocoder.m
@@ -31,7 +31,7 @@ RCT_EXPORT_METHOD(geocodePosition:(CLLocation *)location
   }
 
   if (self.geocoder.geocoding) {
-    return reject(@"NOT_AVAILABLE", @"geocodePosition busy", nil);
+    [self.geocoder cancelGeocode];
   }
 
   [self.geocoder reverseGeocodeLocation:location completionHandler:^(NSArray *placemarks, NSError *error) {
@@ -58,7 +58,7 @@ RCT_EXPORT_METHOD(geocodeAddress:(NSString *)address
     }
 
     if (self.geocoder.geocoding) {
-      return reject(@"NOT_AVAILABLE", @"geocodeAddress busy", nil);
+      [self.geocoder cancelGeocode];
     }
 
     [self.geocoder geocodeAddressString:address completionHandler:^(NSArray *placemarks, NSError *error) {


### PR DESCRIPTION
This is a PR for discussion.

I found that I often send multiple requests and I want the result of the last one but not the first one.
Hence, if a new request is sent, I cancel the previous one to submit the new.

As a result in the JS, I will get only the last one instead of the `busy` error.

Let me know if you want this behind a flag or if it doesn't fit. I'm open for discussion.