### PR TITLE
Update to be RN40+ compatible

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,14 @@
 
 geocoding services for react native
 
+
+## Version table
+| Geocoder Version | RN        |
+| ------- |:----------|
+| >=0.4.6   | >= 0.40.0 |
+| <0.4.5   | <0.40.0   |
+
+
 ## Install
 ```
 npm install --save react-native-geocoder

--- a/ios/RNGeocoder/RNGeocoder.h
+++ b/ios/RNGeocoder/RNGeocoder.h
@@ -1,5 +1,5 @@
-#import "RCTBridgeModule.h"
-#import "RCTConvert.h"
+#import <React/RCTBridgeModule.h>
+#import <React/RCTConvert.h>
 
 #import <CoreLocation/CoreLocation.h>
 

--- a/ios/RNGeocoder/RNGeocoder.m
+++ b/ios/RNGeocoder/RNGeocoder.m
@@ -2,7 +2,7 @@
 
 #import <CoreLocation/CoreLocation.h>
 
-#import "RCTConvert.h"
+#import <React/RCTConvert.h>
 
 @implementation RCTConvert (CoreLocation)
 


### PR DESCRIPTION
This updates the iOS namespace for React to be compatible with React Native 0.40 and above. E.g. `#import RCTConvert.h` becomes `#import <React/RCTConvert.h>`