### PR TITLE
Proposal to add language parameter to get result on preferred language. (iOS only for now, but already added the function in android as well )

### DIFF
--- a/android/src/main/java/com/devfd/RNGeocoder/RNGeocoderModule.java
+++ b/android/src/main/java/com/devfd/RNGeocoder/RNGeocoderModule.java
@@ -31,6 +31,39 @@ public class RNGeocoderModule extends ReactContextBaseJavaModule {
     }
 
     @ReactMethod
+    public void geocodeAddressWithLanguage(String addressName, String language, Promise promise) {
+        if (!geocoder.isPresent()) {
+            promise.reject("NOT_AVAILABLE", "Geocoder not available for this platform");
+            return;
+        }
+        
+        try {
+            List<Address> addresses = geocoder.getFromLocationName(addressName, 20);
+            promise.resolve(transform(addresses));
+        }
+        
+        catch (IOException e) {
+            promise.reject(e);
+        }
+    }
+    
+    @ReactMethod
+    public void geocodePositionWithLanguage(ReadableMap position, String language, Promise promise) {
+        if (!geocoder.isPresent()) {
+            promise.reject("NOT_AVAILABLE", "Geocoder not available for this platform");
+            return;
+        }
+        
+        try {
+            List<Address> addresses = geocoder.getFromLocation(position.getDouble("lat"), position.getDouble("lng"), 20);
+            promise.resolve(transform(addresses));
+        }
+        catch (IOException e) {
+            promise.reject(e);
+        }
+    }
+    
+    @ReactMethod
     public void geocodeAddress(String addressName, Promise promise) {
         if (!geocoder.isPresent()) {
           promise.reject("NOT_AVAILABLE", "Geocoder not available for this platform");

--- a/ios/RNGeocoder/RNGeocoder.h
+++ b/ios/RNGeocoder/RNGeocoder.h
@@ -1,5 +1,5 @@
-#import "RCTBridgeModule.h"
-#import "RCTConvert.h"
+#import <React/RCTBridgeModule.h>
+#import <React/RCTConvert.h>
 
 #import <CoreLocation/CoreLocation.h>
 

--- a/ios/RNGeocoder/RNGeocoder.h
+++ b/ios/RNGeocoder/RNGeocoder.h
@@ -1,5 +1,5 @@
-#import <React/RCTBridgeModule.h>
-#import <React/RCTConvert.h>
+#import "RCTBridgeModule.h"
+#import "RCTConvert.h"
 
 #import <CoreLocation/CoreLocation.h>
 
@@ -9,4 +9,5 @@
 
 @interface RNGeocoder : NSObject<RCTBridgeModule>
 @property (nonatomic, strong) CLGeocoder *geocoder;
+@property (nonatomic, strong) NSString *oldLanguage;
 @end

--- a/ios/RNGeocoder/RNGeocoder.m
+++ b/ios/RNGeocoder/RNGeocoder.m
@@ -2,17 +2,17 @@
 
 #import <CoreLocation/CoreLocation.h>
 
-#import <React/RCTConvert.h>
+#import "RCTConvert.h"
 
 @implementation RCTConvert (CoreLocation)
 
 + (CLLocation *)CLLocation:(id)json
 {
-  json = [self NSDictionary:json];
-
-  double lat = [RCTConvert double:json[@"lat"]];
-  double lng = [RCTConvert double:json[@"lng"]];
-  return [[CLLocation alloc] initWithLatitude:lat longitude:lng];
+    json = [self NSDictionary:json];
+    
+    double lat = [RCTConvert double:json[@"lat"]];
+    double lng = [RCTConvert double:json[@"lng"]];
+    return [[CLLocation alloc] initWithLatitude:lat longitude:lng];
 }
 
 @end
@@ -26,27 +26,33 @@ RCT_EXPORT_METHOD(geocodePosition:(CLLocation *)location
                   resolver:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject)
 {
-  if (!self.geocoder) {
-    self.geocoder = [[CLGeocoder alloc] init];
-  }
-
-  if (self.geocoder.geocoding) {
-    [self.geocoder cancelGeocode];
-  }
-
-  [self.geocoder reverseGeocodeLocation:location completionHandler:^(NSArray *placemarks, NSError *error) {
-
-    if (error) {
-      if (placemarks.count == 0) {
-          return reject(@"NOT_FOUND", @"geocodePosition failed", error);
-      }
-
-      return reject(@"ERROR", @"geocodePosition failed", error);
+    [[NSUserDefaults standardUserDefaults]removeObjectForKey:@"AppleLanguages"];
+    NSString * language = [[NSLocale preferredLanguages] objectAtIndex:0];
+    self.oldLanguage = language;
+    NSLog(@"OLD LANG %@", self.oldLanguage);
+    [[NSUserDefaults standardUserDefaults] setObject:[NSArray arrayWithObjects:@"en", nil] forKey:@"AppleLanguages"];
+    [[NSUserDefaults standardUserDefaults] synchronize];
+    if (!self.geocoder) {
+        self.geocoder = [[CLGeocoder alloc] init];
     }
-
-    resolve([self placemarksToDictionary:placemarks]);
-
-  }];
+    
+    if (self.geocoder.geocoding) {
+        [self.geocoder cancelGeocode];
+    }
+    
+    [self.geocoder reverseGeocodeLocation:location completionHandler:^(NSArray *placemarks, NSError *error) {
+        
+        if (error) {
+            if (placemarks.count == 0) {
+                return reject(@"NOT_FOUND", @"geocodePosition failed", error);
+            }
+            
+            return reject(@"ERROR", @"geocodePosition failed", error);
+        }
+        
+        resolve([self placemarksToDictionary:placemarks]);
+        
+    }];
 }
 
 RCT_EXPORT_METHOD(geocodeAddress:(NSString *)address
@@ -56,67 +62,68 @@ RCT_EXPORT_METHOD(geocodeAddress:(NSString *)address
     if (!self.geocoder) {
         self.geocoder = [[CLGeocoder alloc] init];
     }
-
+    
     if (self.geocoder.geocoding) {
-      [self.geocoder cancelGeocode];
+        [self.geocoder cancelGeocode];
     }
-
+    
     [self.geocoder geocodeAddressString:address completionHandler:^(NSArray *placemarks, NSError *error) {
-
+        
         if (error) {
             if (placemarks.count == 0) {
-              return reject(@"NOT_FOUND", @"geocodeAddress failed", error);
+                return reject(@"NOT_FOUND", @"geocodeAddress failed", error);
             }
-
+            
             return reject(@"ERROR", @"geocodeAddress failed", error);
         }
-
+        
         resolve([self placemarksToDictionary:placemarks]);
-  }];
+    }];
 }
 
 - (NSArray *)placemarksToDictionary:(NSArray *)placemarks {
-
-  NSMutableArray *results = [[NSMutableArray alloc] init];
-
-  for (int i = 0; i < placemarks.count; i++) {
-    CLPlacemark* placemark = [placemarks objectAtIndex:i];
-
-    NSString* name = [NSNull null];
-
-    if (![placemark.name isEqualToString:placemark.locality] &&
-        ![placemark.name isEqualToString:placemark.thoroughfare] &&
-        ![placemark.name isEqualToString:placemark.subThoroughfare])
-    {
-
-        name = placemark.name;
+    
+    NSMutableArray *results = [[NSMutableArray alloc] init];
+    
+    for (int i = 0; i < placemarks.count; i++) {
+        CLPlacemark* placemark = [placemarks objectAtIndex:i];
+        
+        NSString* name = [NSNull null];
+        
+        if (![placemark.name isEqualToString:placemark.locality] &&
+            ![placemark.name isEqualToString:placemark.thoroughfare] &&
+            ![placemark.name isEqualToString:placemark.subThoroughfare])
+        {
+            
+            name = placemark.name;
+        }
+        
+        NSArray *lines = placemark.addressDictionary[@"FormattedAddressLines"];
+        
+        NSDictionary *result = @{
+                                 @"feature": name,
+                                 @"position": @{
+                                         @"lat": [NSNumber numberWithDouble:placemark.location.coordinate.latitude],
+                                         @"lng": [NSNumber numberWithDouble:placemark.location.coordinate.longitude],
+                                         },
+                                 @"country": placemark.country ?: [NSNull null],
+                                 @"countryCode": placemark.ISOcountryCode ?: [NSNull null],
+                                 @"locality": placemark.locality ?: [NSNull null],
+                                 @"subLocality": placemark.subLocality ?: [NSNull null],
+                                 @"streetName": placemark.thoroughfare ?: [NSNull null],
+                                 @"streetNumber": placemark.subThoroughfare ?: [NSNull null],
+                                 @"postalCode": placemark.postalCode ?: [NSNull null],
+                                 @"adminArea": placemark.administrativeArea ?: [NSNull null],
+                                 @"subAdminArea": placemark.subAdministrativeArea ?: [NSNull null],
+                                 @"formattedAddress": [lines componentsJoinedByString:@", "]
+                                 };
+        
+        [results addObject:result];
     }
-
-    NSArray *lines = placemark.addressDictionary[@"FormattedAddressLines"];
-
-    NSDictionary *result = @{
-     @"feature": name,
-     @"position": @{
-         @"lat": [NSNumber numberWithDouble:placemark.location.coordinate.latitude],
-         @"lng": [NSNumber numberWithDouble:placemark.location.coordinate.longitude],
-         },
-     @"country": placemark.country ?: [NSNull null],
-     @"countryCode": placemark.ISOcountryCode ?: [NSNull null],
-     @"locality": placemark.locality ?: [NSNull null],
-     @"subLocality": placemark.subLocality ?: [NSNull null],
-     @"streetName": placemark.thoroughfare ?: [NSNull null],
-     @"streetNumber": placemark.subThoroughfare ?: [NSNull null],
-     @"postalCode": placemark.postalCode ?: [NSNull null],
-     @"adminArea": placemark.administrativeArea ?: [NSNull null],
-     @"subAdminArea": placemark.subAdministrativeArea ?: [NSNull null],
-     @"formattedAddress": [lines componentsJoinedByString:@", "]
-   };
-
-    [results addObject:result];
-  }
-
-  return results;
-
+    [[NSUserDefaults standardUserDefaults] setObject:[NSArray arrayWithObjects:self.oldLanguage, nil] forKey:@"AppleLanguages"];
+    [[NSUserDefaults standardUserDefaults] synchronize];
+    return results;
+    
 }
 
 @end

--- a/ios/RNGeocoder/RNGeocoder.m
+++ b/ios/RNGeocoder/RNGeocoder.m
@@ -1,8 +1,7 @@
 #import "RNGeocoder.h"
 
 #import <CoreLocation/CoreLocation.h>
-
-#import "RCTConvert.h"
+#import <React/RCTConvert.h>
 
 @implementation RCTConvert (CoreLocation)
 

--- a/js/geocoder.js
+++ b/js/geocoder.js
@@ -10,6 +10,28 @@ export default {
     this.apiKey = key;
   },
 
+  geocodePositionWithLanguage(position, language){
+	if (!position || !position.lat || !position.lng) {
+      return Promise.reject(new Error("invalid position: {lat, lng} required"));
+    }
+
+    return RNGeocoder.geocodePositionWithLanguage(position, language).catch(err => {
+      if (!this.apiKey) { throw err; }
+      return GoogleApi.geocodePosition(this.apiKey, position);
+    });
+  }
+
+  geocodeAddressWithLanguage(address, language) {
+    if (!address) {
+      return Promise.reject(new Error("address is null"));
+    }
+
+    return RNGeocoder.geocodeAddressWithLanguage(address, language).catch(err => {
+      if (!this.apiKey) { throw err; }
+      return GoogleApi.geocodeAddress(this.apiKey, address);
+    });
+  },
+  
   geocodePosition(position) {
     if (!position || !position.lat || !position.lng) {
       return Promise.reject(new Error("invalid position: {lat, lng} required"));


### PR DESCRIPTION
User can put language like "en", "id", "en_US", or any formatted language code for set into user devices, then the geocoder will return result base on selected language.
Don't worry if will affect current device language. After set the language with selected language, i also put the language back to original language after get the result.
I create this after saw people had an issue on language, and i also need this feature, so i create this one.
hope will help the community :)

For now only iOS supported, but i have added the function in android as well but not yet fill the logic to change language base on the language parameter, anyone can fill in it pls fill it, while i also ask my friend who has android studio :p 

Thanks ! any question pls comment or msg me abadi_kaka@yahoo.com thx