### PR TITLE
Expose GoogleApi in index.js

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,3 +1,4 @@
 import Geocoder from './js/geocoder.js';
+import GoogleApi from './js/googleApi';
 
-export default Geocoder;
+export { Geocoder as default, GoogleApi};


### PR DESCRIPTION
This will help if projects want to use Google API only for supported requests.