### PR TITLE
Handle Android RN 0.47 breaking change

### DIFF
--- a/android/src/main/java/com/devfd/RNGeocoder/RNGeocoderPackage.java
+++ b/android/src/main/java/com/devfd/RNGeocoder/RNGeocoderPackage.java
@@ -20,7 +20,7 @@ public class RNGeocoderPackage implements ReactPackage {
     );
   }
 
-  @Override
+    // Deprecated RN 0.47
     public List<Class<? extends JavaScriptModule>> createJSModules() {
       return Collections.emptyList();
     }


### PR DESCRIPTION
The createJSModules method was removed from ReactPackage in version 0.47. Removing the override annotation will stop compiler errors in 0.47 while continuing to work in previous versions.