### PR TITLE
Handle FormattedAddressLines being null

### DIFF
--- a/ios/RNGeocoder/RNGeocoder.m
+++ b/ios/RNGeocoder/RNGeocoder.m
@@ -109,7 +109,7 @@ RCT_EXPORT_METHOD(geocodeAddress:(NSString *)address
      @"postalCode": placemark.postalCode ?: [NSNull null],
      @"adminArea": placemark.administrativeArea ?: [NSNull null],
      @"subAdminArea": placemark.subAdministrativeArea ?: [NSNull null],
-     @"formattedAddress": [lines componentsJoinedByString:@", "]
+     @"formattedAddress": [lines componentsJoinedByString:@", "] ?: [NSNull null]
    };
 
     [results addObject:result];


### PR DESCRIPTION
I get occasional crashes of the form:
```
Fatal Exception: NSInvalidArgumentException
0  CoreFoundation                 0x184ecafe0 __exceptionPreprocess
1  libobjc.A.dylib                0x18392c538 objc_exception_throw
2  CoreFoundation                 0x184db19b4 -[__NSPlaceholderDictionary initWithObjects:forKeys:count:]
3  CoreFoundation                 0x184db1824 +[NSDictionary dictionaryWithObjects:forKeys:count:]
4  DanceDeets                     0x1004162a4 -[RNGeocoder placemarksToDictionary:] (RNGeocoder.m:97)
5  DanceDeets                     0x1004159d4 __47-[RNGeocoder geocodeAddress:resolver:rejecter:]_block_invoke (RNGeocoder.m:74)
...
```

with:
```
Fatal Exception: NSInvalidArgumentException
*** -[__NSPlaceholderDictionary initWithObjects:forKeys:count:]: attempt to insert nil object from objects[11]
```