### PR TITLE
Adds support for 0 latitude or 0 longitude

### DIFF
--- a/js/geocoder.js
+++ b/js/geocoder.js
@@ -11,7 +11,7 @@ export default {
   },
 
   geocodePosition(position) {
-    if (!position || !position.lat || !position.lng) {
+    if (!position || (!position.lat && position.lat!==0) || (!position.lng && position.lng!==0)) {
       return Promise.reject(new Error("invalid position: {lat, lng} required"));
     }
 

--- a/js/googleApi.js
+++ b/js/googleApi.js
@@ -59,7 +59,7 @@ function format(raw) {
 
 export default {
   geocodePosition(apiKey, position) {
-    if (!apiKey || !position || !position.lat || !position.lng) {
+    if (!apiKey || !position || (!position.lat && position.lat!==0) || (!position.lng && position.lng!==0)) {
       return Promise.reject(new Error("invalid apiKey / position"));
     }
 

--- a/test/unit/geocoder.test.js
+++ b/test/unit/geocoder.test.js
@@ -52,6 +52,12 @@ describe('geocoder', function() {
       expect(RNGeocoder.geocodePosition).to.have.been.calledWith(position);
     });
 
+    it ('returns geocoding results with 0 lat and lng', async function() {
+      const position = {lat: 0, lng: 0};
+      await Geocoder.geocodePosition(position);
+      expect(RNGeocoder.geocodePosition).to.have.been.calledWith(position);
+    });
+
     it ('does not call google api if no apiKey', function() {
       const position = {lat: 1.234, lng: 4.567};
       RNGeocoder.geocodePosition = sinon.stub().returns(Promise.reject());

--- a/test/unit/googleApi.test.js
+++ b/test/unit/googleApi.test.js
@@ -22,6 +22,13 @@ describe('googleApi', function() {
       expect(ret).to.eql('yo');
     });
 
+    it ('position', async function() {
+      let ret = await GoogleApi.geocodePosition('myKey', {lat: 0, lng: 0});
+      expect(geocodeRequest).to.have.been.calledWith(
+        'https://maps.google.com/maps/api/geocode/json?key=myKey&latlng=0,0');
+      expect(ret).to.eql('yo');
+    });
+
     it ('address', async function() {
       let ret = await GoogleApi.geocodeAddress('myKey', "london");
       expect(geocodeRequest).to.have.been.calledWith(


### PR DESCRIPTION
In the current status of Master if the User is on latitude or longitude `0` the library throw an error.
However the position (in the latitude or the longitude) `0` must be a valid position.

I have fixed the issues (for the Native functions and for Google API) and also I have added the pertinent tests.

Thanks