### PR TITLE
Enable specifying custom SDK and Build Tools versions

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,12 +1,16 @@
 apply plugin: 'com.android.library'
 
+def DEFAULT_COMPILE_SDK_VERSION = 25
+def DEFAULT_BUILD_TOOLS_VERSION = "25.0.2"
+def DEFAULT_TARGET_SDK_VERSION  = 25
+
 android {
-    compileSdkVersion 25
-    buildToolsVersion "25.0.2"
+    compileSdkVersion rootProject.hasProperty('compileSdkVersion') ? rootProject.compileSdkVersion : DEFAULT_COMPILE_SDK_VERSION
+    buildToolsVersion rootProject.hasProperty('buildToolsVersion') ? rootProject.buildToolsVersion : DEFAULT_BUILD_TOOLS_VERSION
 
     defaultConfig {
         minSdkVersion 16
-        targetSdkVersion 25
+        rootProject.hasProperty('targetSdkVersion') ? rootProject.targetSdkVersion : DEFAULT_TARGET_SDK_VERSION
         versionCode 1
         versionName "1.0"
         ndk {


### PR DESCRIPTION
This solves APK building problems that arise due to differing SDK and Build Tools versions of the Root project and 'react-native-config'.

Without this, Android apps that use this dependency cannot be built, throwing the following error:

```
Warning: The rule `-keep public class *extends java.lang.annotation.Annotation {
  *;
}` uses extends but actually matches implements.
/Users/dusan-mitipi/.gradle/caches/transforms-1/files-1.1/appcompat-v7-26.1.0.aar/8e5c28697d7a976e3f3189250ef54cfd/res/values-v26/values-v26.xml:13:5-16:13: AAPT: No resource found that matches the given name: attr 'android:keyboardNavigationCluster'.

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':react-native-geocoder:verifyReleaseResources'.
> com.android.ide.common.process.ProcessException: Failed to execute aapt
```