### PR TITLE
build.gradle: Replace 'compile' with 'implementation'

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -16,6 +16,6 @@ android {
 }
 
 dependencies {
-    compile fileTree(include: ['*.jar'], dir: 'libs')
-    compile "com.facebook.react:react-native:+"
+    implementation fileTree(include: ['*.jar'], dir: 'libs')
+    implementation "com.facebook.react:react-native:+"
 }


### PR DESCRIPTION
WARNING: Configuration 'compile' is obsolete and has been replaced with 'implementation' and 'api'.
It will be removed in version 5.0 of the Android Gradle plugin.
For more information, see http://d.android.com/r/tools/update-dependency-configurations.html.